### PR TITLE
allow no auth

### DIFF
--- a/conf/appconfig.py
+++ b/conf/appconfig.py
@@ -1,8 +1,8 @@
 import os
 import yaml
 
-MONGO_USERNAME = os.getenv('MONGO_USERNAME', '')
-MONGO_PASSWORD = os.getenv('MONGO_PASSWORD', '')
+MONGO_USERNAME = os.getenv('MONGO_USERNAME', None)
+MONGO_PASSWORD = os.getenv('MONGO_PASSWORD', None)
 MONGO_URL = os.getenv('MONGO_URL', 'mongodb://localhost:27017')
 MONGO_INCLUDES = os.getenv('MONGO_INCLUDES', '')
 


### PR DESCRIPTION
(See proposed changes).  Using empty strings (`''`) causes mongo-connector to try to auth with an empty username and password instead of no auth.  See https://github.com/mongodb-labs/mongo-connector/blob/master/mongo_connector/connector.py#L262.

Stacktrace without the proposed change: 

```
Logging to mongo-connector.log.
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.4/dist-packages/mongo_connector/util.py", line 85, in wrapped
    func(*args, **kwargs)
  File "/usr/local/lib/python3.4/dist-packages/mongo_connector/connector.py", line 262, in run
    main_conn['admin'].authenticate(self.auth_username, self.auth_key)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/database.py", line 982, in authenticate
    self.connection._cache_credentials(self.name, credentials)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/mongo_client.py", line 468, in _cache_credentials
    auth.authenticate(credentials, sock_info, self.__simple_command)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/auth.py", line 475, in authenticate
    auth_func(credentials[1:], sock_info, cmd_func)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/auth.py", line 450, in _authenticate_default
    return _authenticate_scram_sha1(credentials, sock_info, cmd_func)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/auth.py", line 238, in _authenticate_scram_sha1
    sasl_start, sasl_continue)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/auth.py", line 185, in _scram_sha1_conversation
    res, _ = cmd_func(sock_info, source, sasl_start)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/mongo_client.py", line 704, in __simple_command
    helpers._check_command_response(response, None, msg)
  File "/usr/local/lib/python3.4/dist-packages/pymongo/helpers.py", line 182, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
pymongo.errors.OperationFailure: command SON([('saslStart', 1), ('mechanism', 'SCRAM-SHA-1'), ('autoAuthorize', 1), ('payload', Binary(b'n,,n=,r=NTMyMTgzMDA1MzQ5NjQ0Mg==', 0))]) on namespace admin.$cmd failed: Authentication failed.
```
