### PR TITLE
0.2.0 Release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.idea
+*.iml
+*.md
+LICENSE
+*.git*
+oplog.timestamp

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ target/
 *.iml
 .idea
 mongo-connector.json
+oplog.timestamp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM totem/python-base:3.4-trusty-b2
+FROM python:3.5-alpine
 
 # App dependencies
 ADD requirements.txt /opt/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ADD . /opt/mongo-connector/
 
 WORKDIR /opt/mongo-connector
 
-CMD ["/opt/mongo-connector/run.py"]
+CMD ["python3", "/opt/mongo-connector/run.py"]

--- a/README.md
+++ b/README.md
@@ -63,3 +63,6 @@ mongo-connector:
 ```
 
 Note:  List of complete mongo-connector settings can be found in [mongo-connector wiki](https://github.com/10gen-labs/mongo-connector/wiki/Configuration-Options)
+
+### LOG_VERBOSITY
+Verbosity for logging (between 0 - 3,  where 0 is ERROR,  3 is DEBUG)

--- a/conf/appconfig.py
+++ b/conf/appconfig.py
@@ -10,6 +10,8 @@ ES_URL = os.getenv('ES_URL', 'http://localhost:9200')
 ES_INDEXES = yaml.load(os.getenv('ES_INDEXES') or '{}')
 ES_TIMEOUT_SECONDS = int(os.getenv('ES_TIMEOUT_SECONDS', '100'))
 
+LOG_VERBOSITY = int(os.getenv('LOG_VERBOSITY', 2))
+
 MONGO_CONNECTOR_CONFIG = 'mongo-connector.json'
 
 DEFAULTS = {
@@ -38,8 +40,14 @@ DEFAULTS = {
                     }
                 }
             }
-        ]
-    }
+        ],
+        'logging': {
+            'type': 'stream'
+        },
+        'verbosity': LOG_VERBOSITY,
+        'continueOnError': True
+    },
+
 }
 
 CONFIG_LOCATION = os.getenv('CONFIG_LOCATION')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-# mongo-connector==2.1
-# Use latest mongo connector (for troubleshooting issue with fatal exception)
-https://github.com/mongodb-labs/mongo-connector/archive/master.tar.gz
-elasticsearch==1.6.0
-pymongo==2.8.1
+mongo-connector==2.3.0
+elastic-doc-manager
+elasticsearch>=1.0.0,<2.0.0
+pymongo==3.2.2
 requests
 PyYAML==3.11


### PR DESCRIPTION
- Upgrade mongo-es to 2.3.0
- Use alpine docker image (python3.5)
- Upgrade pymongo to 3.2.2 (Better connection handling)
- Continue on error during startup (do not fail)
